### PR TITLE
Port from GObject to GLib

### DIFF
--- a/info_view.py
+++ b/info_view.py
@@ -25,6 +25,8 @@ from periodic_elements import ELEMENTS_DATA
 
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("EvinceDocument", "3.0")
+gi.require_version("EvinceView", "3.0")
 
 from gi.repository import Gtk
 from gi.repository import EvinceDocument

--- a/table.py
+++ b/table.py
@@ -36,6 +36,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
 from gi.repository import GObject
+from gi.repository import GLib
 
 ITEM_SIZE = min(Gdk.Screen.width() / 21, Gdk.Screen.height() / 13)
 
@@ -146,9 +147,9 @@ class TempScale(Gtk.HBox):
         self.entry.set_text(text)
 
         if self._reset_id is not None:
-            GObject.source_remove(self._reset_id)
+            GLib.source_remove(self._reset_id)
 
-        self._reset_id = GObject.timeout_add(2000, self.reset)
+        self._reset_id = GLib.timeout_add(2000, self.reset)
 
     def __entry_activated_cb(self, widget):
         self.__update_value(int(self.entry.get_text()))
@@ -165,11 +166,11 @@ class TempScale(Gtk.HBox):
 
         self.emit("value-changed", self.value)
 
-        GObject.idle_add(self.queue_draw)
+        GLib.idle_add(self.queue_draw)
 
     def reset(self):
         if self._reset_id is not None:
-            GObject.source_remove(self._reset_id)
+            GLib.source_remove(self._reset_id)
             self._reset_id = None
 
         self.emit("reset")
@@ -418,10 +419,10 @@ class Table(Gtk.ScrolledWindow):
         self.detailed_item = None
 
     def __temp_changed(self, scale, value):
-        GObject.idle_add(self.update_temperature, value)
+        GLib.idle_add(self.update_temperature, value)
 
     def __reset_temp(self, scale):
-        GObject.idle_add(self.update_temperature, None)
+        GLib.idle_add(self.update_temperature, None)
 
     def update_temperature(self, temp):
         for item in self.items:

--- a/toolbarbox.py
+++ b/toolbarbox.py
@@ -22,7 +22,7 @@ from periodic_elements import ELEMENTS_DATA
 import gi
 gi.require_version("Gtk", "3.0")
 
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GObject, GLib
 
 from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.graphics import iconentry
@@ -96,7 +96,7 @@ class PeriodicTableToolbarBox(ToolbarBox):
     def _search_entry_activated_cb(self, search_entry):
         pattern = search_entry.get_text()
         if self._autosearch_timer:
-            GObject.source_remove(self._autosearch_timer)
+            GLib.source_remove(self._autosearch_timer)
             self._autosearch_timer = None
             found_elements = []
             for key, element in ELEMENTS_DATA.iteritems():
@@ -109,8 +109,8 @@ class PeriodicTableToolbarBox(ToolbarBox):
             self._search_entry_activated_cb(search_entry)
 
         if self._autosearch_timer:
-            GObject.source_remove(self._autosearch_timer)
-        self._autosearch_timer = GObject.timeout_add(
+            GLib.source_remove(self._autosearch_timer)
+        self._autosearch_timer = GLib.timeout_add(
             750,
             self._search_entry_activated_cb,
             search_entry


### PR DESCRIPTION
### Explanation
This PR ports GObject based methods to GLib. 

### Reason
Thousands of PyGIDeprecationWarning occur in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### Test result
No error related to the port from GObject to GLib. 
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/periodic-table$ sugar-activity
/home/tonadev/Documents/Work/OpenSource/code_in/sugarlabs/periodic-table/info_view.py:30: PyGIWarning: EvinceDocument was imported without specifying a version first. Use gi.require_version('EvinceDocument', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import EvinceDocument
/home/tonadev/Documents/Work/OpenSource/code_in/sugarlabs/periodic-table/info_view.py:31: PyGIWarning: EvinceView was imported without specifying a version first. Use gi.require_version('EvinceView', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import EvinceView

(sugar-activity:7149): Gtk-WARNING **: 13:55:24.392: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:7149): Gtk-WARNING **: 13:55:24.392: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version

```
