### PR TITLE
Port to python 3

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -3,4 +3,4 @@ name = Periodic Table
 activity_version = 1
 bundle_id = org.sugarlabs.PeriodicTable
 icon = icon
-exec = sugar-activity activity.PeriodicTable 
+exec = sugar-activity3 activity.PeriodicTable 

--- a/periodic_elements.py
+++ b/periodic_elements.py
@@ -22,15 +22,15 @@ from gettext import gettext as _
 
 
 class Element:
-    H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P = range(1, 16)
-    S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn = range(16, 31)
-    Ga, Ge, As, Se, Br, Kr, Rb, Sr, Y, Zr, Nb, Mo, Tc, Ru = range(31, 45)
-    Rh, Pd, Ag, Cd, In, Sn, Sb, Te, I, Xe, Cs, Ba, La, Ce = range(45, 59)
-    Pr, Nd, Pm, Sm, Eu, Gd, Tb, Dy, Ho, Er, Tm, Yb, Lu, Hf = range(59, 73)
-    Ta, W, Re, Os, Ir, Pt, Au, Hg, Tl, Pb, Bi, Po, At, Rn = range(73, 87)
-    Fr, Ra, Ac, Th, Pa, U, Np, Pu, Am, Cm, Bk, Cf, Es, Fm = range(87, 101)
-    Md, No, Lr, Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn, Uut = range(101, 114)
-    Fl, Uup, Lv, Uus, Uuo = range(114, 119)
+    H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P = list(range(1, 16))
+    S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn = list(range(16, 31))
+    Ga, Ge, As, Se, Br, Kr, Rb, Sr, Y, Zr, Nb, Mo, Tc, Ru = list(range(31, 45))
+    Rh, Pd, Ag, Cd, In, Sn, Sb, Te, I, Xe, Cs, Ba, La, Ce = list(range(45, 59))
+    Pr, Nd, Pm, Sm, Eu, Gd, Tb, Dy, Ho, Er, Tm, Yb, Lu, Hf = list(range(59, 73))
+    Ta, W, Re, Os, Ir, Pt, Au, Hg, Tl, Pb, Bi, Po, At, Rn = list(range(73, 87))
+    Fr, Ra, Ac, Th, Pa, U, Np, Pu, Am, Cm, Bk, Cf, Es, Fm = list(range(87, 101))
+    Md, No, Lr, Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn, Uut = list(range(101, 114))
+    Fl, Uup, Lv, Uus, Uuo = list(range(114, 119))
 
 
 class Category:

--- a/table.py
+++ b/table.py
@@ -405,7 +405,7 @@ class Table(Gtk.ScrolledWindow):
         self.show_all()
 
     def __item_selected_cb(self, item):
-        element = ELEMENTS_DATA.values().index(item.element) + 1
+        element = list(ELEMENTS_DATA.values()).index(item.element) + 1
         self.emit("element-selected", element)
 
     def __item_enter_cb(self, item):

--- a/toolbarbox.py
+++ b/toolbarbox.py
@@ -99,7 +99,7 @@ class PeriodicTableToolbarBox(ToolbarBox):
             GLib.source_remove(self._autosearch_timer)
             self._autosearch_timer = None
             found_elements = []
-            for key, element in ELEMENTS_DATA.iteritems():
+            for key, element in ELEMENTS_DATA.items():
                 if match(pattern, element):
                     found_elements.append(element["number"])
             self.emit("searched-element", found_elements)


### PR DESCRIPTION
This fixes https://github.com/sugarlabs/periodic-table/issues/9. Tested both with `suger-activity3` and in a local sugar environment. Although `2to3` suggests amendment of the unicode escape sequences in `periodic_elements.py`, with the fact that python 3 now stores strings as unicode literals, amendment of these escapes does not appear to be required and is a false positive.